### PR TITLE
fix: tsx building and embed title

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Discord で簡単なプログラムを実行するためのボットです。
 言語 | 実行 | 整形 | ビルド
 --- | :---: | :---: | :---:
 JavaScript | ✓ | ✓ |
+JSX | | ✓ | ✓
 TypeScript | ✓ | ✓ | ✓
 TSX | | ✓ | ✓
 CoffeeScript | ✓ | ✓ | ✓

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Discord で簡単なプログラムを実行するためのボットです。
 言語 | 実行 | 整形 | ビルド
 --- | :---: | :---: | :---:
 JavaScript | ✓ | ✓ |
-JSX | | ✓ | ✓
+JSX | | ✓ |
 TypeScript | ✓ | ✓ | ✓
 TSX | | ✓ | ✓
 CoffeeScript | ✓ | ✓ | ✓

--- a/src/building/base.ts
+++ b/src/building/base.ts
@@ -29,6 +29,7 @@ export abstract class BaseBuildingSystem {
     if (!result) result = '返り値がありません';
     return createMessageFromText(result, {
       title: 'ビルド結果',
+      showTitleOnEmbed: true,
       embedColor: this.embedColor,
       lang: this.resultLanguage,
     });

--- a/src/building/typescript.ts
+++ b/src/building/typescript.ts
@@ -18,6 +18,7 @@ export class TypeScriptBuildingSystem extends BaseBuildingSystem {
         noImplicitUseStrict: true,
         alwaysStrict: false,
         strict: false,
+        jsx: ts.JsxEmit.Preserve,
       },
     });
     return Promise.resolve(outputText);

--- a/src/manager/CodeLintManager.ts
+++ b/src/manager/CodeLintManager.ts
@@ -1,6 +1,7 @@
 import type { BaseMessageOptions } from 'discord.js';
-import { AttachmentBuilder, Colors } from 'discord.js';
+import { Colors } from 'discord.js';
 import prettier from 'prettier';
+import { createMessageFromText } from '../util';
 import type { Language } from '../interface';
 
 const { format } = prettier;
@@ -41,28 +42,10 @@ export class CodeLintManager {
 }
 
 function createMessage(code: string, lang: Language): BaseMessageOptions {
-  if (code.length <= 4080) {
-    return {
-      embeds: [
-        {
-          title: '整形結果(Prettier 標準設定)',
-          description: `\`\`\`${lang}\n${code}\n\`\`\``,
-          color: Colors.Blurple,
-        },
-      ],
-    };
-  }
-
-  if (Buffer.from(code).byteLength / 1024 / 1024 > 8) {
-    return {
-      content: '整形結果が 8GB を超えるファイルになってしまいました',
-    };
-  }
-
-  return {
-    content: '整形結果です。ファイルをご覧ください。',
-    files: [
-      new AttachmentBuilder(Buffer.from(code), { name: `result.${lang}` }),
-    ],
-  };
+  return createMessageFromText(code, {
+    title: '整形結果(Prettier 標準設定)',
+    showTitleOnEmbed: true,
+    embedColor: Colors.Blurple,
+    lang,
+  });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,12 @@ export function createMessageFromText(
     embedColor,
     lang,
     showTitleOnEmbed = false,
-  }: { title: string; embedColor: ColorResolvable; lang?: string, showTitleOnEmbed?:boolean }
+  }: {
+    title: string;
+    embedColor: ColorResolvable;
+    lang?: string;
+    showTitleOnEmbed?: boolean;
+  }
 ) {
   if (result.length <= 4080) {
     const embed = new EmbedBuilder()

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,12 +7,14 @@ export function createMessageFromText(
     title,
     embedColor,
     lang,
-  }: { title: string; embedColor: ColorResolvable; lang?: string }
+    showTitleOnEmbed = false,
+  }: { title: string; embedColor: ColorResolvable; lang?: string, showTitleOnEmbed?:boolean }
 ) {
   if (result.length <= 4080) {
     const embed = new EmbedBuilder()
       .setColor(embedColor)
-      .setDescription(`\`\`\`${lang ?? ''}\n${result}\n\`\`\``);
+      .setDescription(`\`\`\`${lang ?? ''}\n${result}\n\`\`\``)
+      .setTitle(showTitleOnEmbed ? title : null);
     return { embeds: [embed] };
   }
 
@@ -39,6 +41,7 @@ export function createMessageFromText(
   }
 
   return {
+    title: showTitleOnEmbed ? title : undefined,
     content,
     files: [new AttachmentBuilder(Buffer.from(result), { name: 'result.txt' })],
   };


### PR DESCRIPTION
```md
* 対応している言語の票にJSXを追加した
* ビルド結果なのか実行結果なのかわかりにくかったからビルド結果っていうタイトルが出るようにした
* これに伴ってCodeLintManagerもutil.tsのcreateMessageFromText()を使うようにした
* TSXのビルドがおかしくなってたから修正した
```